### PR TITLE
Improve Flow type coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-tests/
+coverage/
+.nyc_output/
+
+.DS_Store
+npm-debug.log
+yarn-error.log
+
+/flow-typed/npm/**

--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,4 +1,10 @@
-// @flow
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
 
 declare var __NODE__: boolean;
 declare var __BROWSER__: boolean;

--- a/flow-typed/just-safe-get.js
+++ b/flow-typed/just-safe-get.js
@@ -1,0 +1,8 @@
+// @flow
+
+declare module 'just-safe-get' {
+  declare export default function get(
+    obj: mixed,
+    key: string | Array<string>
+  ): mixed;
+}

--- a/flow-typed/just-safe-set.js
+++ b/flow-typed/just-safe-set.js
@@ -1,0 +1,9 @@
+// @flow
+
+declare module 'just-safe-set' {
+  declare export default function set(
+    obj: mixed,
+    key: string | Array<string>,
+    value: mixed
+  ): boolean;
+}

--- a/flow-typed/npm/jsonwebtoken_v8.1.x.js
+++ b/flow-typed/npm/jsonwebtoken_v8.1.x.js
@@ -1,0 +1,112 @@
+// flow-typed signature: a2d5ea66c7bcab10e48b4d9cf6fcbcb0
+// flow-typed version: 40e00ed01a/jsonwebtoken_v8.1.x/flow_>=v0.56.x
+
+declare module "jsonwebtoken" {
+  declare module.exports: {
+    sign: jwt$Sign,
+    decode: jwt$Decode,
+    verify: jwt$Verify,
+    JsonWebTokenError: Class<jwt$WebTokenError>,
+    NotBeforeError: Class<jwt$NotBeforeError>,
+    TokenExpiredError: Class<jwt$TokenExpiredError>
+  }
+}
+
+declare type jwt$Encodable = String | Buffer | Object;
+declare type jwt$Key = { key: string | Buffer, passphrase: string | Buffer };
+declare type jwt$Algorithm =
+  'RS256'
+  | 'RS384'
+  | 'RS512'
+  | 'ES256'
+  | 'ES384'
+  | 'ES512'
+  | 'HS256'
+  | 'HS384'
+  | 'HS512'
+  | 'none';
+
+declare type jwt$Callback = (tokenOrError: Error | string) => void;
+declare type jwt$SigningOptions<Headers> = $Shape<{
+  algorithm: jwt$Algorithm,
+  expiresIn: number | string,
+  notBefore: number | string,
+  audience: string | string[],
+  issuer: string,
+  jwtid: string,
+  subject: string,
+  noTimestamp: boolean,
+  header: Headers,
+  keyid: string
+}>;
+
+declare type jwt$SigningOptionsWithAlgorithm<H> = jwt$SigningOptions<H> & { algorithm: jwt$Algorithm };
+declare type jwt$VerifyOptionsWithAlgorithm = jwt$VerifyOptions & { algorithms: Array<jwt$Algorithm> };
+
+declare type jwt$VerifyOptions = $Shape<{
+  algorithms: Array<jwt$Algorithm>,
+  audience: string,
+  issuer: string | string[],
+  ignoreExpiration: boolean,
+  ignoreNotBefore: boolean,
+  subject: string | string[],
+  clockTolerance: number,
+  maxAge: string | number,
+  clockTimestamp: number
+}>;
+
+declare type jwt$DecodingOptions = $Shape<{
+  complete: boolean,
+  json: boolean,
+  encoding: string,
+}>;
+
+declare interface jwt$Sign {
+  <P: jwt$Encodable>
+  (payload: P, secretOrPrivateKey: string | Buffer): string;
+
+  <P: jwt$Encodable>
+  (payload: P, secretOrPrivateKey: string | Buffer, callback: jwt$Callback): string;
+
+  <P: jwt$Encodable, H>
+  (payload: P, secretOrPrivateKey: jwt$Key, options: jwt$SigningOptionsWithAlgorithm<H>): string;
+
+  <P: jwt$Encodable, H>
+  (payload: P, secretOrPrivateKey: string | Buffer, options: $Shape<jwt$SigningOptions<H>>): string;
+
+  <P: jwt$Encodable, H>
+  (payload: P, secretOrPrivateKey: string | Buffer, options: $Shape<jwt$SigningOptions<H>>, callback: jwt$Callback): string;
+
+  <P: jwt$Encodable, H>
+  (payload: P, secretOrPrivateKey: jwt$Key, options: jwt$SigningOptionsWithAlgorithm<H>, callback: jwt$Callback): string;
+}
+
+declare interface jwt$Decode {
+  (jwt: string): mixed;
+
+  (jwt: string, options: jwt$DecodingOptions): mixed;
+
+  (jwt: string, options: jwt$DecodingOptions & { complete: true }): { header: Object, payload: mixed, signature: string };
+}
+
+declare interface jwt$Verify {
+  (jwt: string, secretOrPrivateKey: string | Buffer): mixed;
+
+  (jwt: string, secretOrPrivateKey: string | Buffer, options: jwt$VerifyOptions | jwt$Callback): mixed;
+
+  (jwt: string, secretOrPrivateKey: string | Buffer, options: jwt$VerifyOptions, callback: jwt$Callback): mixed;
+
+  (jwt: string, secretOrPrivateKey: jwt$Key, options: jwt$VerifyOptionsWithAlgorithm): mixed;
+
+  (jwt: string, secretOrPrivateKey: jwt$Key, options: jwt$VerifyOptionsWithAlgorithm, callback: jwt$Callback): mixed;
+}
+
+declare class jwt$TokenExpiredError extends Error {
+}
+
+declare class jwt$WebTokenError extends Error {
+}
+
+declare class jwt$NotBeforeError extends Error {
+}
+

--- a/flow-typed/npm/node-fetch_v1.x.x.js
+++ b/flow-typed/npm/node-fetch_v1.x.x.js
@@ -1,0 +1,106 @@
+// flow-typed signature: 284e255a331cbe00e3ddf88897c9452d
+// flow-typed version: 7e7beb7540/node-fetch_v1.x.x/flow_>=v0.44.x
+
+declare module 'node-fetch' {
+  declare export class Request mixins Body {
+    constructor(input: string | Request, init?: RequestInit): this;
+    method: string;
+    url: string;
+    headers: Headers;
+    context: RequestContext;
+    referrer: string;
+    redirect: RequestRedirect;
+
+    // node-fetch extensions
+    compress: boolean;
+    agent: http$Agent;
+    counter: number;
+    follow: number;
+    hostname: string;
+    protocol: string;
+    port: number;
+    timeout: number;
+    size: number
+  }
+
+  declare type HeaderObject = {
+    [index: string]: string
+  }
+
+  declare interface RequestInit {
+    method?: string,
+    headers?: HeaderObject,
+    body?: BodyInit,
+    redirect?: RequestRedirect,
+
+    // node-fetch extensions
+    timeout?: number,
+    compress?: boolean,
+    size?: number,
+    agent?: http$Agent,
+    follow?: number
+  }
+
+  declare type RequestContext =
+    'audio' | 'beacon' | 'cspreport' | 'download' | 'embed' |
+    'eventsource' | 'favicon' | 'fetch' | 'font' | 'form' | 'frame' |
+    'hyperlink' | 'iframe' | 'image' | 'imageset' | 'import' |
+    'internal' | 'location' | 'manifest' | 'object' | 'ping' | 'plugin' |
+    'prefetch' | 'script' | 'serviceworker' | 'sharedworker' |
+    'subresource' | 'style' | 'track' | 'video' | 'worker' |
+    'xmlhttprequest' | 'xslt';
+  declare type RequestRedirect = 'follow' | 'error' | 'manual';
+
+  declare export class Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string;
+    getAll(name: string): Array<string>;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    forEach(callback: (value: string, name: string) => void): void
+  }
+
+  declare export class Body {
+    bodyUsed: boolean;
+    body: stream$Readable;
+    json(): Promise<any>;
+    json<T>(): Promise<T>;
+    text(): Promise<string>;
+    buffer(): Promise<Buffer >
+  }
+
+  declare export class Response mixins Body {
+    constructor(body?: BodyInit, init?: ResponseInit): this;
+    error(): Response;
+    redirect(url: string, status: number): Response;
+    type: ResponseType;
+    url: string;
+    status: number;
+    ok: boolean;
+    size: number;
+    statusText: string;
+    timeout: number;
+    headers: Headers;
+    clone(): Response
+  }
+
+  declare type ResponseType =
+    | 'basic'
+    | 'cors'
+    | 'default'
+    | 'error'
+    | 'opaque'
+    | 'opaqueredirect';
+
+  declare interface ResponseInit {
+    status: number,
+    statusText?: string,
+    headers?: HeaderInit
+  }
+
+  declare type HeaderInit = Headers | Array<string>;
+  declare type BodyInit = string;
+
+  declare export default function fetch(url: string | Request, init?: RequestInit): Promise<Response>
+}

--- a/flow-typed/tape-cup_v4.x.x.js
+++ b/flow-typed/tape-cup_v4.x.x.js
@@ -1,0 +1,105 @@
+/* eslint-disable  */
+
+declare type tape$TestOpts = {
+  skip: boolean,
+  timeout?: number,
+} | {
+  skip?: boolean,
+  timeout: number,
+};
+
+declare type tape$TestCb = (t: tape$Context) => mixed;
+declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
+
+declare interface tape$Context {
+  fail(msg?: string): void,
+  pass(msg?: string): void,
+
+  error(err: mixed, msg?: string): void,
+  ifError(err: mixed, msg?: string): void,
+  ifErr(err: mixed, msg?: string): void,
+  iferror(err: mixed, msg?: string): void,
+
+  ok(value: mixed, msg?: string): void,
+  true(value: mixed, msg?: string): void,
+  assert(value: mixed, msg?: string): void,
+
+  notOk(value: mixed, msg?: string): void,
+  false(value: mixed, msg?: string): void,
+  notok(value: mixed, msg?: string): void,
+
+  // equal + aliases
+  equal(actual: mixed, expected: mixed, msg?: string): void,
+  equals(actual: mixed, expected: mixed, msg?: string): void,
+  isEqual(actual: mixed, expected: mixed, msg?: string): void,
+  is(actual: mixed, expected: mixed, msg?: string): void,
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notEqual + aliases
+  notEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquals(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNot(actual: mixed, expected: mixed, msg?: string): void,
+  not(actual: mixed, expected: mixed, msg?: string): void,
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isInequal(actual: mixed, expected: mixed, msg?: string): void,
+
+  // deepEqual + aliases
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  same(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notDeepEqual
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  notSame(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void,
+
+  // deepLooseEqual
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  // notDeepLooseEqual
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void,
+
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void,
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void,
+
+  timeoutAfter(ms: number): void,
+
+  skip(msg?: string): void,
+  plan(n: number): void,
+  onFinish(fn: Function): void,
+  end(): void,
+  comment(msg: string): void,
+  test: tape$TestFn,
+}
+
+declare module 'tape-cup' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+
+  declare type Tape = {
+    (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>): void,
+    test: tape$TestFn,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable,
+    only: (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "eslint . --ignore-path .gitignore",
+    "lint": "eslint . --ignore-path .eslintignore",
     "transpile": "npm run clean && cup build",
     "build-test": "rm -rf dist-tests && cup build-tests",
     "just-test":

--- a/src/__tests__/flow.node.js
+++ b/src/__tests__/flow.node.js
@@ -5,6 +5,7 @@
  *
  * @flow
  */
+
 import tape from 'tape-cup';
 import App from 'fusion-core';
 import {SessionToken} from 'fusion-tokens';

--- a/src/__tests__/interface.node.js
+++ b/src/__tests__/interface.node.js
@@ -1,3 +1,11 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import test from 'tape-cup';
 import Plugin, {
   SessionCookieExpiresToken,

--- a/src/__tests__/test.browser.js
+++ b/src/__tests__/test.browser.js
@@ -2,6 +2,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
 import tape from 'tape-cup';

--- a/src/__tests__/test.node.js
+++ b/src/__tests__/test.node.js
@@ -11,15 +11,15 @@ import App, {createToken} from 'fusion-core';
 import type {Token} from 'fusion-core';
 import {createServer} from 'http';
 import fetch from 'node-fetch';
+import type {Session} from 'fusion-tokens';
+
 import JWTServer, {
   SessionSecretToken,
   SessionCookieNameToken,
   SessionCookieExpiresToken,
 } from '../index';
 
-import type {SessionService} from '../types.js';
-
-const JWTToken: Token<SessionService> = createToken('Session');
+const JWTToken: Token<Session> = createToken('Session');
 
 tape('JWTServer', async t => {
   const app = new App('fake-element', el => el);

--- a/src/__tests__/test.node.js
+++ b/src/__tests__/test.node.js
@@ -17,7 +17,7 @@ import JWTServer, {
   SessionCookieExpiresToken,
 } from '../index';
 
-import type {SessionService} from '../jwt-server';
+import type {SessionService} from '../types.js';
 
 const JWTToken: Token<SessionService> = createToken('Session');
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
-// @flow
 // Main export file
 import browser from './jwt-browser';
 import server from './jwt-server';
@@ -15,7 +16,6 @@ import {
   SessionSecretToken,
 } from './tokens';
 
-declare var __BROWSER__: Boolean;
 export default (__BROWSER__ ? browser : server);
 
 export {SessionCookieExpiresToken, SessionCookieNameToken, SessionSecretToken};

--- a/src/jwt-browser.js
+++ b/src/jwt-browser.js
@@ -2,6 +2,13 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
-export default null;
+import type {FusionPlugin} from 'fusion-core';
+import type {Session} from 'fusion-tokens';
+
+import type {SessionDeps} from './types.js';
+
+export default ((null: any): FusionPlugin<SessionDeps, Session>);

--- a/src/jwt-server.js
+++ b/src/jwt-server.js
@@ -2,9 +2,10 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
  */
 
-// @flow
 /* eslint-env node */
 
 import assert from 'assert';
@@ -22,6 +23,7 @@ import {
   SessionCookieNameToken,
   SessionCookieExpiresToken,
 } from './tokens.js';
+import type {SessionDeps, SessionService} from './types.js';
 
 // Scope path to `data.` here since `jsonwebtoken` has some special top-level keys that we do not want to expose (ex: `exp`)
 const getFullPath = keyPath => `data.${keyPath}`;
@@ -33,7 +35,7 @@ type JWTConfig = {
 };
 
 class JWTSession {
-  cookie: string;
+  cookie: string | void;
   token: ?Object | string;
   config: JWTConfig;
 
@@ -51,14 +53,14 @@ class JWTSession {
     }
     return this.token;
   }
-  get(keyPath: string) {
+  get(keyPath: string): mixed {
     assert(
       this.token,
       "Cannot access token before loaded, please use this plugin before any of it's dependencies"
     );
     return get(this.token, getFullPath(keyPath));
   }
-  set(keyPath: string, val: any) {
+  set(keyPath: string, val: *): boolean {
     assert(
       this.token,
       "Cannot access token before loaded, please use this plugin before any of it's dependencies"
@@ -67,64 +69,46 @@ class JWTSession {
   }
 }
 
-export type SessionService = {
-  from(
-    ctx: Context
-  ): {
-    loadToken(): ?Object | string,
-    get(keyPath: string): any,
-    set(keyPath: string, val: any): void,
+const p: FusionPlugin<SessionDeps, SessionService> = createPlugin({
+  deps: {
+    secret: SessionSecretToken,
+    cookieName: SessionCookieNameToken,
+    expires: SessionCookieExpiresToken.optional,
   },
-};
-
-type SessionDeps = {
-  secret: typeof SessionSecretToken,
-  cookieName: typeof SessionCookieNameToken,
-  expires: typeof SessionCookieExpiresToken.optional,
-};
-const p: FusionPlugin<SessionDeps, SessionService> =
-  // $FlowFixMe
-  __NODE__ &&
-  createPlugin({
-    deps: {
-      secret: SessionSecretToken,
-      cookieName: SessionCookieNameToken,
-      expires: SessionCookieExpiresToken.optional,
-    },
-    provides: deps => {
-      const {secret, cookieName, expires = 86400} = deps;
-      const service = {
-        from: memoize((ctx: Context) => {
-          return new JWTSession(ctx, {secret, cookieName, expires});
-        }),
-      };
-      return service;
-    },
-    middleware: (deps, service) => {
-      const {secret, cookieName, expires = 86400} = deps;
-      return async function jwtMiddleware(
-        ctx: Context,
-        next: () => Promise<void>
-      ) {
-        const sign = promisify(jwt.sign.bind(jwt));
-        const session = service.from(ctx);
-        const token = await session.loadToken();
-        await next();
-        if (token) {
-          // $FlowFixMe
-          delete token.exp; // Clear previous exp time and instead use `expiresIn` option below
-          const time = Date.now(); // get time *before* async signing
-          const signed = await sign(token, secret, {
-            expiresIn: expires,
-          });
-          if (signed !== session.cookie) {
-            const msExpires = new Date(time + expires * 1000);
-            // TODO(#3) provide way to not set cookie if not needed yet
-            ctx.cookies.set(cookieName, signed, {expires: msExpires});
-          }
+  provides: deps => {
+    const {secret, cookieName, expires = 86400} = deps;
+    const service: SessionService = {
+      from: memoize((ctx: Context) => {
+        return new JWTSession(ctx, {secret, cookieName, expires});
+      }),
+    };
+    return service;
+  },
+  middleware: (deps, service) => {
+    const {secret, cookieName, expires = 86400} = deps;
+    return async function jwtMiddleware(
+      ctx: Context,
+      next: () => Promise<void>
+    ) {
+      const sign = promisify(jwt.sign.bind(jwt));
+      const session = service.from(ctx);
+      const token = await session.loadToken();
+      await next();
+      if (token) {
+        // $FlowFixMe
+        delete token.exp; // Clear previous exp time and instead use `expiresIn` option below
+        const time = Date.now(); // get time *before* async signing
+        const signed = await sign(token, secret, {
+          expiresIn: expires,
+        });
+        if (signed !== session.cookie) {
+          const msExpires = new Date(time + expires * 1000);
+          // TODO(#3) provide way to not set cookie if not needed yet
+          ctx.cookies.set(cookieName, signed, {expires: msExpires});
         }
-      };
-    },
-  });
+      }
+    };
+  },
+});
 
 export default ((p: any): FusionPlugin<SessionDeps, Session>);

--- a/src/jwt-server.js
+++ b/src/jwt-server.js
@@ -60,7 +60,7 @@ class JWTSession {
     );
     return get(this.token, getFullPath(keyPath));
   }
-  set(keyPath: string, val: *): boolean {
+  set(keyPath: string, val: mixed): boolean {
     assert(
       this.token,
       "Cannot access token before loaded, please use this plugin before any of it's dependencies"

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,4 +1,11 @@
-// @flow
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import type {Token} from 'fusion-core';
 import {createToken} from 'fusion-core';
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,31 @@
+/** Copyright (c) 2018 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Context} from 'fusion-core';
+
+import {
+  SessionSecretToken,
+  SessionCookieNameToken,
+  SessionCookieExpiresToken,
+} from './tokens.js';
+
+export type SessionService = {
+  from(
+    ctx: Context
+  ): {
+    loadToken(): Promise<?Object | string>,
+    get(keyPath: string): mixed,
+    set(keyPath: string, val: mixed): boolean,
+  },
+};
+
+export type SessionDeps = {
+  secret: typeof SessionSecretToken,
+  cookieName: typeof SessionCookieNameToken,
+  expires: typeof SessionCookieExpiresToken.optional,
+};


### PR DESCRIPTION
Fixes [#644](https://app.zenhub.com/workspace/o/uber-web/web-platform-tasks/issues/644)

```
#### Problem/Rationale

Fusion.js packages, with the exception of `fusion-core` do not export [libdef](https://flow.org/en/docs/libdefs/) and consumers rely on the Flow type definitions embedded in the source code.  Given this, it is a pain point for consumers when type definitions are missing or incomplete.

We should also strive for full Flow coverage to minimize issues within our own packages.

#### Solution/Change/Deliverable

Two-fold:
* Reach 100% Flow coverage on exported type definitions.
* Strive for 100% Flow coverage internally for each package.
```

<img width="623" alt="screen shot 2018-03-28 at 3 12 13 pm" src="https://user-images.githubusercontent.com/3497835/38059210-6d1bac3c-329a-11e8-8bfa-dcf7222aeb3f.png">
